### PR TITLE
fix: correção na dependência (versão) e exigências do modelMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,13 @@
 			<artifactId>rest-assured</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
 		<dependency>
-  			<groupId>org.modelmapper</groupId>
-  			<artifactId>modelmapper</artifactId>
-  			<version>2.3.0</version>
+			<groupId>org.modelmapper.extensions</groupId>
+			<artifactId>modelmapper-spring</artifactId>
+			<version>3.0.0</version>
 		</dependency>
+
 		<dependency>
         	<groupId>org.codehaus.groovy</groupId>
         	<artifactId>groovy</artifactId><!--apagar dps de atualizar o spring-->

--- a/src/main/java/com/nesrux/jmfood/api/classconversion/assembler/CidadeOutputAssembler.java
+++ b/src/main/java/com/nesrux/jmfood/api/classconversion/assembler/CidadeOutputAssembler.java
@@ -13,7 +13,7 @@ import com.nesrux.jmfood.domain.model.endereco.Cidade;
 @Component
 public class CidadeOutputAssembler {
 	@Autowired
-	private ModelMapper modelMapper = new ModelMapper();
+	private ModelMapper modelMapper;
 
 	public CidadeOutputDto toModel(Cidade cidade) {
 		return modelMapper.map(cidade, CidadeOutputDto.class);

--- a/src/main/java/com/nesrux/jmfood/core/modelmapper/ModelMapperConfig.java
+++ b/src/main/java/com/nesrux/jmfood/core/modelmapper/ModelMapperConfig.java
@@ -1,19 +1,24 @@
 package com.nesrux.jmfood.core.modelmapper;
 
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.nesrux.jmfood.api.model.dto.output.restaurante.RestauranteOutputDto;
+import com.nesrux.jmfood.domain.model.restaurante.Restaurante;
 
 @Configuration
 public class ModelMapperConfig {
 
 	@Bean
 	public ModelMapper modelMapper() {
-		var modelMapper = new ModelMapper();
+		ModelMapper modelMapper = new ModelMapper();
+		
 		/*Configuracoes do modelMapper para fazer mapeamento de propriedades com nomes difetenstes*/
 		//Nesse caso, não muda em absolutamente nada ter essa config ou não ter, é apenas didatico.
-		//modelMapper.createTypeMap(Restaurante.class, RestauranteOutputDTO.class)
-			//.addMapping(Restaurante::getTaxaFrete, RestauranteOutputDTO::setTaxaFrete);
+		modelMapper.createTypeMap(Restaurante.class, RestauranteOutputDto.class)
+			.addMapping(Restaurante::getTaxaFrete, RestauranteOutputDto::setTaxaFrete);
 		
 		
 		

--- a/src/main/java/com/nesrux/jmfood/domain/model/restaurante/Restaurante.java
+++ b/src/main/java/com/nesrux/jmfood/domain/model/restaurante/Restaurante.java
@@ -70,8 +70,10 @@ public class Restaurante {
 
 	@OneToMany(mappedBy = "restaurante")
 	private List<Produto> produtos = new ArrayList<>();
-	
-	
+
+	public Restaurante() {
+	}
+
 	public void ativar() {
 		setAtivo(true);
 	}
@@ -79,5 +81,7 @@ public class Restaurante {
 	public void desativar() {
 		setAtivo(false);
 	}
+
+	
 
 }


### PR DESCRIPTION
O modelMapper possui versões diferentes pra cada tipo de sistema na qual ele está sendo integrado (neste caso o Spring Boot).  [**Veja aqui**](https://modelmapper.org/downloads/).
A versão anterior era uma de uso geral e não específica para o Spring.

Havia também algumas convenções para injeções de dependência do Spring que não estavam sendo utilizadas e algumas exigências para o modelMapper como um construtor público entre as classes que estão sendo mapeadas que foi adicionado.